### PR TITLE
Add lang packages and update HTTP URLs

### DIFF
--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -3,6 +3,11 @@ syntax = "proto3";
 package temporal.api.cloud.cloudservice.v1;
 
 option go_package = "go.temporal.io/api/cloud/cloudservice/v1;cloudservice";
+option java_package = "io.temporal.api.cloud.cloudservice.v1";
+option java_multiple_files = true;
+option java_outer_classname = "RequestResponseProto";
+option ruby_package = "Temporalio::Api::Cloud::CloudService::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.CloudService.V1";
 
 import "temporal/api/cloud/operation/v1/message.proto";
 import "temporal/api/cloud/identity/v1/message.proto";

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -12,6 +12,8 @@ option csharp_namespace = "Temporalio.Api.Cloud.CloudService.V1";
 import "temporal/api/cloud/cloudservice/v1/request_response.proto";
 import "google/api/annotations.proto";
 
+// WARNING: This service is currently experimental and may change in
+// incompatible ways.
 service CloudService {
     // Gets all known users
     rpc GetUsers(GetUsersRequest) returns (GetUsersResponse) {

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -3,6 +3,11 @@ syntax = "proto3";
 package temporal.api.cloud.cloudservice.v1;
 
 option go_package = "go.temporal.io/api/cloud/cloudservice/v1;cloudservice";
+option java_package = "io.temporal.api.cloud.cloudservice.v1";
+option java_multiple_files = true;
+option java_outer_classname = "ServiceProto";
+option ruby_package = "Temporalio::Api::Cloud::CloudService::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.CloudService.V1";
 
 import "temporal/api/cloud/cloudservice/v1/request_response.proto";
 import "google/api/annotations.proto";
@@ -11,21 +16,21 @@ service CloudService {
     // Gets all known users
     rpc GetUsers(GetUsersRequest) returns (GetUsersResponse) {
         option (google.api.http) = {
-            get: "/api/v1/users",
+            get: "/api/v1/cloud/users",
         };
     }
     
     // Get a user
     rpc GetUser(GetUserRequest) returns (GetUserResponse) {
         option (google.api.http) = {
-            get: "/api/v1/users/{user_id}",
+            get: "/api/v1/cloud/users/{user_id}",
         };
     }
 
     // Create a user
     rpc CreateUser(CreateUserRequest) returns (CreateUserResponse) {
         option (google.api.http) = {
-            post: "/api/v1/users",
+            post: "/api/v1/cloud/users",
             body: "*"
         };
     }
@@ -33,7 +38,7 @@ service CloudService {
     // Update a user
     rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse) {
         option (google.api.http) = {
-            post: "/api/v1/users/{user_id}",
+            post: "/api/v1/cloud/users/{user_id}",
             body: "*"
         };
     }
@@ -41,14 +46,14 @@ service CloudService {
     // Delete a user
     rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) {
         option (google.api.http) = {
-            delete: "/api/v1/users/{user_id}",
+            delete: "/api/v1/cloud/users/{user_id}",
         };
     }
 
     // Set a user's access to a namespace
     rpc SetUserNamespaceAccess(SetUserNamespaceAccessRequest) returns (SetUserNamespaceAccessResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/users/{user_id}/access",
+            post: "/api/v1/cloud/namespaces/{namespace}/users/{user_id}/access",
             body: "*"
         };
     }
@@ -56,14 +61,14 @@ service CloudService {
     // Get the latest information on an async operation
     rpc GetAsyncOperation(GetAsyncOperationRequest) returns (GetAsyncOperationResponse) {
         option (google.api.http) = {
-            get: "/api/v1/operations/{async_operation_id}",
+            get: "/api/v1/cloud/operations/{async_operation_id}",
         };
     }
 
     // Create a new namespace
     rpc CreateNamespace (CreateNamespaceRequest) returns (CreateNamespaceResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces",
+            post: "/api/v1/cloud/namespaces",
             body: "*"
         };
     }
@@ -71,21 +76,21 @@ service CloudService {
     // Get all namespaces
     rpc GetNamespaces (GetNamespacesRequest)  returns (GetNamespacesResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces",
+            get: "/api/v1/cloud/namespaces",
         };
     }
 
     // Get a namespace
     rpc GetNamespace (GetNamespaceRequest) returns (GetNamespaceResponse) {
         option (google.api.http) = {
-            get: "/api/v1/namespaces/{namespace}",
+            get: "/api/v1/cloud/namespaces/{namespace}",
         };
     }
 
     // Update a namespace
     rpc UpdateNamespace (UpdateNamespaceRequest) returns (UpdateNamespaceResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}",
+            post: "/api/v1/cloud/namespaces/{namespace}",
             body: "*"
         };
     }
@@ -93,7 +98,7 @@ service CloudService {
     // Rename an existing customer search attribute
     rpc RenameCustomSearchAttribute (RenameCustomSearchAttributeRequest) returns (RenameCustomSearchAttributeResponse) {
         option (google.api.http) = {
-            post: "/api/v1/namespaces/{namespace}/rename-custom-search-attribute",
+            post: "/api/v1/cloud/namespaces/{namespace}/rename-custom-search-attribute",
             body: "*"
         };
     }
@@ -101,21 +106,21 @@ service CloudService {
     // Delete a namespace
     rpc DeleteNamespace (DeleteNamespaceRequest) returns (DeleteNamespaceResponse) {
         option (google.api.http) = {
-            delete: "/api/v1/namespaces/{namespace}",
+            delete: "/api/v1/cloud/namespaces/{namespace}",
         };
     }
 
     // Get all regions
     rpc GetRegions (GetRegionsRequest) returns (GetRegionsResponse) {
         option (google.api.http) = {
-            get: "/api/v1/regions",
+            get: "/api/v1/cloud/regions",
         };
     }
 
     // Get a region
     rpc GetRegion (GetRegionRequest) returns (GetRegionResponse) {
         option (google.api.http) = {
-            get: "/api/v1/regions/{region}",
+            get: "/api/v1/cloud/regions/{region}",
         };
     }
 }

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -3,6 +3,11 @@ syntax = "proto3";
 package temporal.api.cloud.identity.v1;
 
 option go_package = "go.temporal.io/api/cloud/identity/v1;identity";
+option java_package = "io.temporal.api.cloud.identity.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Identity::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Identity.V1";
 
 import "google/protobuf/timestamp.proto";
 
@@ -64,5 +69,3 @@ message User {
     // Will not be set if the user has never been modified.
     google.protobuf.Timestamp last_modified_time = 8;
 }
-
-

--- a/temporal/api/cloud/namespace/v1/message.proto
+++ b/temporal/api/cloud/namespace/v1/message.proto
@@ -3,6 +3,11 @@ syntax = "proto3";
 package temporal.api.cloud.namespace.v1;
 
 option go_package = "go.temporal.io/api/cloud/namespace/v1;namespace";
+option java_package = "io.temporal.api.cloud.namespace.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Namespace::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Namespace.V1";
 
 import "google/protobuf/timestamp.proto";
 
@@ -24,6 +29,8 @@ message CertificateFilterSpec {
 message MtlsAuthSpec {
     // The base64 encoded ca cert(s) in PEM format that the clients can use for authentication and authorization.
     // This must only be one value, but the CA can have a chain.
+    //
+    // (-- api-linter: core::0140::base64=disabled --)
     string accepted_client_ca = 1;
     // Certificate filters which, if specified, only allow connections from client certificates whose distinguished name properties match at least one of the filters.
     // This allows limiting access to specific end-entity certificates.

--- a/temporal/api/cloud/operation/v1/message.proto
+++ b/temporal/api/cloud/operation/v1/message.proto
@@ -3,6 +3,11 @@ syntax = "proto3";
 package temporal.api.cloud.operation.v1;
 
 option go_package = "go.temporal.io/api/cloud/operation/v1;operation";
+option java_package = "io.temporal.api.cloud.operation.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Operation::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Operation.V1";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
@@ -19,6 +24,8 @@ message AsyncOperation {
     // The type of operation being performed
     string operation_type = 4;
     // The input to the operation being performed
+    //
+    // (-- api-linter: core::0146::any=disabled --)
     google.protobuf.Any operation_input = 5;
     // If the operation failed, the reason for the failure
     string failure_reason = 6;

--- a/temporal/api/cloud/region/v1/message.proto
+++ b/temporal/api/cloud/region/v1/message.proto
@@ -3,6 +3,11 @@ syntax = "proto3";
 package temporal.api.cloud.region.v1;
 
 option go_package = "go.temporal.io/api/cloud/region/v1;region";
+option java_package = "io.temporal.api.cloud.region.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Region::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Region.V1";
 
 message Region {
     // The id of the temporal cloud region.
@@ -15,4 +20,3 @@ message Region {
     // The human readable location of the region.
     string location = 4;
 }
-


### PR DESCRIPTION
## What was changed

* Added needed lang-specific options to top of files
* Updated HTTP API annotations to have `/api/v1/cloud/` prefix to make this easier to edge route when combined with other HTTP API on the same endpoint (this may change again)
* Added comment to top of cloud service saying it is experimental and may change incompatibly
* Couple of API linter ignores (these aren't really needed since this repo isn't merging into primary one yet, can remove if necessary)
* Fixed end-of-file newline inconsistency

Once merged, I can use git submodule/subtree to allow this to be referenced in the primary API repo. Do y'all want me to disable the buf-breaking check in code (to re-enable in later PR) or do y'all want to admin-bypass?