### PR TITLE
Add service account CRUD APIs

### DIFF
--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -331,3 +331,74 @@ message SetUserGroupNamespaceAccessResponse {
     // The async operation.
     temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
 }
+
+message CreateServiceAccountRequest {
+    // The spec of the service account to create.
+    temporal.api.cloud.identity.v1.ServiceAccountSpec spec = 1;
+    // The ID to use for this async operation - optional.
+    string async_operation_id = 2;
+}
+
+message CreateServiceAccountResponse {
+    // The ID of the created service account.
+    string service_account_id = 1;
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 2;
+}
+
+message GetServiceAccountRequest {
+    // ID of the service account to retrieve.
+    string service_account_id = 1;
+}
+
+message GetServiceAccountResponse {
+    // The service account retrieved.
+    temporal.api.cloud.identity.v1.ServiceAccount service_account = 1;
+}
+
+message GetServiceAccountsRequest {
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 1;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 2;
+}
+
+message GetServiceAccountsResponse {
+    // The list of service accounts in ascending ID order.
+    repeated temporal.api.cloud.identity.v1.ServiceAccount service_account = 1;
+    // The next page token, set if there is another page.
+    string next_page_token = 2;
+}
+
+message UpdateServiceAccountRequest {
+    // The ID of the service account to update.
+    string service_account_id = 1;
+    // The new service account specification.
+    temporal.api.cloud.identity.v1.ServiceAccountSpec spec = 2;
+    // The version of the service account for which this update is intended for.
+    // The latest version can be found in the GetServiceAccount response.
+    string resource_version = 3;
+    // The ID to use for this async operation - optional.
+    string async_operation_id = 4;
+}
+
+message UpdateServiceAccountResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message DeleteServiceAccountRequest {
+    // The ID of the service account to delete;
+    string service_account_id = 1;
+    // The version of the service account for which this update is intended for.
+    // The latest version can be found in the GetServiceAccount response.
+    string resource_version = 2;
+    // The ID to use for this async operation - optional.
+    string async_operation_id = 3;
+}
+
+message DeleteServiceAccountResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -170,4 +170,41 @@ service CloudService {
             body: "*"
         };
     }
+
+    // Create a service account.
+    rpc CreateServiceAccount(CreateServiceAccountRequest) returns (CreateServiceAccountResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/service-accounts",
+            body: "*"
+        };
+    }
+
+    // Get a service account.
+    rpc GetServiceAccount(GetServiceAccountRequest) returns (GetServiceAccountResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/service-accounts/{service_account_id}",
+        };
+    }
+
+    // Get service accounts.
+    rpc GetServiceAccounts(GetServiceAccountsRequest) returns (GetServiceAccountsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/service-accounts",
+        };
+    }
+
+    // Update a service account.
+    rpc UpdateServiceAccount(UpdateServiceAccountRequest) returns (UpdateServiceAccountResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/service-accounts/{service_account_id}",
+            body: "*"
+        };
+    }
+
+    // Delete a service account.
+    rpc DeleteServiceAccount(DeleteServiceAccountRequest) returns (DeleteServiceAccountResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/service-accounts/{service_account_id}",
+        };
+    }
 }

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -96,3 +96,37 @@ message UserGroup {
     // Will not be set if the group has never been modified
     google.protobuf.Timestamp last_modified_time = 7;
 }
+
+message ServiceAccount {
+    // The id of the service account.
+    string id = 1;
+    // The current version of the service account specification.
+    // The next update operation will have to include this version.
+    string resource_version = 2;
+    // The service account specification.
+    ServiceAccountSpec spec = 3;
+    // The current state of the service account.
+    // Possible values: activating, activationfailed, active, updating, updatefailed, deleting, deletefailed, deleted, suspending, suspendfailed, suspended.
+    // For any failed state, reach out to Temporal Cloud support for remediation.
+    string state = 4;
+    // The id of the async operation that is creating/updating/deleting the service account, if any.
+    string async_operation_id = 5;
+    // The date and time when the service account was created.
+    google.protobuf.Timestamp created_time = 6;
+    // The date and time when the service account was last modified
+    // Will not be set if the service account has never been modified.
+    google.protobuf.Timestamp last_modified_time = 7;
+}
+
+message ServiceAccountSpec {
+    // The name associated with the service account.
+    // The name is mutable, but must be unique across all your active service accounts.
+    string name = 1;
+    // The access assigned to the service account.
+    // The access is mutable.
+    Access access = 2;
+    // The description associated with the service account - optional.
+    // The description is mutable.
+    string description = 3;
+}
+


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds CRUD APIs for service accounts.

## Why?
<!-- Tell your future self why have you made these changes -->
To enable automated management of service accounts.

## Checklist
- [x] Generated protos with `make proto`.