### PR TITLE
Switch buf.yaml config to FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Copy over the protobuf files under [temporal](temporal) directory to the project
 The client is expected to pass in a `temporal-cloud-api-version` header with the api version identifier with every request it makes to the apis. The backend will use the version to safely mutate resources. The `temporal:versioning:min_version` label specifies the minimum version of the API that supports the field.
 
 Current Version:
-
 https://github.com/temporalio/api-cloud/blob/main/VERSION#L1C1-L1C14
 
 ### URL

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Copy over the protobuf files under [temporal](temporal) directory to the project
 
 ### API Version
 
-The client is expected to pass in a `temporal-cloud-api-version` header with the api version identifier with every request it makes to the apis. The backend will use the version to safely mutate resources. The `temporal:versioning:min_version` label indicates the minimun version of the API required to use the field.
+The client is expected to pass in a `temporal-cloud-api-version` header with the api version identifier with every request it makes to the apis. The backend will use the version to safely mutate resources. The `temporal:versioning:min_version` label specifies the minimum version of the API that supports the field.
 
 Current Version:
 

--- a/buf.yaml
+++ b/buf.yaml
@@ -3,7 +3,7 @@ deps:
   - buf.build/googleapis/googleapis
 breaking:
   use:
-    - WIRE
+    - FILE
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
Switches `buf.yaml` config back to `FILE` now that https://github.com/temporalio/api-cloud/pull/28 is merged.