### PR TITLE
[Breaking] Reorg the user-group apis with a explicit google group spec field.

### DIFF
--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -360,13 +360,13 @@ message GetUserGroupsRequest {
     string namespace = 3;
     // Filter groups by the display name - optional.
     string display_name = 4;
+    // Filter groups by the google group specification - optional.
+    GoogleGroupFilter google_group = 5;
 
     message GoogleGroupFilter {
         // Filter groups by the google group email - optional.
         string email_address = 1;
     }
-    // Filter groups by the google group specification - optional.
-    GoogleGroupFilter google_group = 5;
 }
 
 message GetUserGroupsResponse {

--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -349,7 +349,6 @@ message DeleteApiKeyResponse {
     temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
 }
 
-
 message GetUserGroupsRequest {
     // The requested size of the page to retrieve - optional.
     // Cannot exceed 1000. Defaults to 100.

--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -359,12 +359,9 @@ message GetUserGroupsRequest {
     string namespace = 3;
     // Filter groups by the display name - optional.
     string display_name = 4;
-    // Filter groups by the group type - optional.
-    // Possible values: google-group
-    string group_type = 5;
     // Filter groups by the google group email - optional.
-    // Only applicable when group_type filter is set to google group-type.
-    string google_group_email_address = 6;
+    // Only applies to google groups.
+    string google_group_email_address = 5;
 }
 
 message GetUserGroupsResponse {

--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -349,10 +349,6 @@ message DeleteApiKeyResponse {
     temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
 }
 
-message GoogleGroupGetUserGroupsFilter {
-    // Filter groups by the google group email - optional.
-    string email_address = 1;
-}
 
 message GetUserGroupsRequest {
     // The requested size of the page to retrieve - optional.
@@ -364,8 +360,13 @@ message GetUserGroupsRequest {
     string namespace = 3;
     // Filter groups by the display name - optional.
     string display_name = 4;
+
+    message GoogleGroupFilter {
+        // Filter groups by the google group email - optional.
+        string email_address = 1;
+    }
     // Filter groups by the google group specification - optional.
-    GoogleGroupGetUserGroupsFilter google_group = 5;
+    GoogleGroupFilter google_group = 5;
 }
 
 message GetUserGroupsResponse {

--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -349,6 +349,11 @@ message DeleteApiKeyResponse {
     temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
 }
 
+message GoogleGroupGetUserGroupsFilter {
+    // Filter groups by the google group email - optional.
+    string email_address = 1;
+}
+
 message GetUserGroupsRequest {
     // The requested size of the page to retrieve - optional.
     // Cannot exceed 1000. Defaults to 100.
@@ -359,9 +364,8 @@ message GetUserGroupsRequest {
     string namespace = 3;
     // Filter groups by the display name - optional.
     string display_name = 4;
-    // Filter groups by the google group email - optional.
-    // Only applies to google groups.
-    string google_group_email_address = 5;
+    // Filter groups by the google group specification - optional.
+    GoogleGroupGetUserGroupsFilter google_group = 5;
 }
 
 message GetUserGroupsResponse {

--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -357,6 +357,14 @@ message GetUserGroupsRequest {
     string page_token = 2;
     // Filter groups by the namespace they have access to - optional.
     string namespace = 3;
+    // Filter groups by the display name - optional.
+    string display_name = 4;
+    // Filter groups by the group type - optional.
+    // Possible values: google-group
+    string group_type = 5;
+    // Filter groups by the google group email - optional.
+    // Only applicable when group_type filter is set to google group-type.
+    string google_group_email_address = 6;
 }
 
 message GetUserGroupsResponse {

--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -357,8 +357,6 @@ message GetUserGroupsRequest {
     string page_token = 2;
     // Filter groups by the namespace they have access to - optional.
     string namespace = 3;
-    // Filter groups by their name - optional.
-    string group_name = 4;
 }
 
 message GetUserGroupsResponse {

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -85,9 +85,9 @@ message UserGroupSpec {
     // Currently, the only supported type is 'google-group'.
     // The type is immutable. Once set during creation, it cannot be changed.
     string type = 3;
-    // The specification of the Google group.
+    // The specification of the google group.
     // This field is required when the group type is 'google-group'.
-    GoogleGroupSpec google_group_spec = 4;
+    GoogleGroupSpec google_group = 4;
 }
 
 message UserGroup {

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -72,13 +72,13 @@ message User {
 
 message GoogleGroupSpec {
     // The email address of the Google group.
-    // THe email address is immutable. Once set during creation, it cannot be changed.
-    string email = 1;
+    // The email address is immutable. Once set during creation, it cannot be changed.
+    string email_address = 1;
 }
 
 message UserGroupSpec {
     // The display name of the group.
-    string name = 1;
+    string display_name = 1;
     // The access assigned to the group.
     Access access = 2;
     // The type of the group.

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -82,6 +82,7 @@ message UserGroupSpec {
     // The access assigned to the group.
     Access access = 2;
     // The specification of the google group that this group is associated with.
+    // For now only google groups are supported, and this field is required.
     GoogleGroupSpec google_group = 3;
 }
 

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -81,13 +81,8 @@ message UserGroupSpec {
     string display_name = 1;
     // The access assigned to the group.
     Access access = 2;
-    // The type of the group.
-    // Currently, the only supported type is 'google-group'.
-    // The type is immutable. Once set during creation, it cannot be changed.
-    string type = 3;
-    // The specification of the google group.
-    // This field is required when the group type is 'google-group'.
-    GoogleGroupSpec google_group = 4;
+    // The specification of the google group that this group is associated with.
+    GoogleGroupSpec google_group = 3;
 }
 
 message UserGroup {

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -70,12 +70,24 @@ message User {
     google.protobuf.Timestamp last_modified_time = 8;
 }
 
+message GoogleGroupSpec {
+    // The email address of the Google group.
+    // THe email address is immutable. Once set during creation, it cannot be changed.
+    string email = 1;
+}
+
 message UserGroupSpec {
-    // The name of the group as defined in the customer's IdP (e.g. Google group name in Google Workspace)
-    // The name is immutable. Once set, it cannot be changed
+    // The display name of the group.
     string name = 1;
-    // The access assigned to the group
+    // The access assigned to the group.
     Access access = 2;
+    // The type of the group.
+    // Currently, the only supported type is 'google-group'.
+    // The type is immutable. Once set during creation, it cannot be changed.
+    string type = 3;
+    // The specification of the Google group.
+    // This field is required when the group type is 'google-group'.
+    GoogleGroupSpec google_group_spec = 4;
 }
 
 message UserGroup {


### PR DESCRIPTION
This change is backward incompatible. But we control who and how its being used. Should be safe to merge.
