### PR TITLE
Update CreateBillingReport and GetBillingReport tags

### DIFF
--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -1133,7 +1133,7 @@ service CloudService {
             body: "*"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            tags: ["Account"];
+            tags: ["Billing"];
             summary: "Create a billing report";
             description: "Creates a billing report for the account";
             external_docs: {
@@ -1149,7 +1149,7 @@ service CloudService {
             get: "/cloud/billing-reports/{billing_report_id}"
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            tags: ["Account"];
+            tags: ["Billing"];
             summary: "Get a billing report";
             description: "Gets an existing billing report for the account";
             external_docs: {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OpenAPI metadata-only change that just reclassifies two RPCs in generated docs; low risk aside from tooling expecting the previous `Account` tag.
> 
> **Overview**
> Updates the OpenAPI operation tags for `CreateBillingReport` and `GetBillingReport` in `service.proto`, moving them from **`Account`** to **`Billing`** so these endpoints group under billing-related documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b13c524b67edff299f7572d4b40e446cb16165db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->