### PR TITLE
Add Get<>NamespaceAssignments APIs

### DIFF
--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -1168,3 +1168,54 @@ message DeleteCustomRoleResponse {
     // The async operation.
     temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
 }
+
+message GetUserNamespaceAssignmentsRequest {
+    // The namespace to get users for.
+    string namespace = 1;
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 2;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 3;
+}
+
+message GetUserNamespaceAssignmentsResponse {
+    // The list of users with access to the namespace.
+    repeated temporal.api.cloud.identity.v1.UserNamespaceAssignment users = 1;
+    // The next page's token.
+    string next_page_token = 2;
+}
+
+message GetServiceAccountNamespaceAssignmentsRequest {
+    // The namespace to get service accounts for.
+    string namespace = 1;
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 2;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 3;
+}
+
+message GetServiceAccountNamespaceAssignmentsResponse {
+    // The list of service accounts with access to the namespace.
+    repeated temporal.api.cloud.identity.v1.ServiceAccountNamespaceAssignment service_accounts = 1;
+    // The next page's token.
+    string next_page_token = 2;
+}
+
+message GetUserGroupNamespaceAssignmentsRequest {
+    // The namespace to get user groups for.
+    string namespace = 1;
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 2;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 3;
+}
+
+message GetUserGroupNamespaceAssignmentsResponse {
+    // The list of user groups with access to the namespace.
+    repeated temporal.api.cloud.identity.v1.UserGroupNamespaceAssignment groups = 1;
+    // The next page's token.
+    string next_page_token = 2;
+}

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -1249,7 +1249,7 @@ service CloudService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: ["Users"];
             summary: "List users with access to a namespace";
-            description: "Returns the users that have access to the namespace, including each user's namespace-level access and whether that access is inherited from an account or project role.";
+            description: "Returns the users that have access to the namespace, including each user's namespace permission.";
             external_docs: {
                 url: "https://docs.temporal.io/cloud/users";
                 description: "Users documentation";
@@ -1265,7 +1265,7 @@ service CloudService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: ["Service Accounts"];
             summary: "List service accounts with access to a namespace";
-            description: "Returns the service accounts that have access to the namespace, including each service account's namespace-level access and whether that access is inherited from an account or project role.";
+            description: "Returns the service accounts that have access to the namespace, including each service account's namespace permission.";
             external_docs: {
                 url: "https://docs.temporal.io/cloud/service-accounts";
                 description: "Service Accounts documentation";
@@ -1281,7 +1281,7 @@ service CloudService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: ["Groups"];
             summary: "List user groups with access to a namespace";
-            description: "Returns the user groups that have access to the namespace, including each group's namespace-level access and whether that access is inherited from an account or project role.";
+            description: "Returns the user groups that have access to the namespace, including each group's namespace permission.";
             external_docs: {
                 url: "https://docs.temporal.io/cloud/user-groups";
                 description: "User groups documentation";

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -1241,7 +1241,7 @@ service CloudService {
         };
     }
 
-    // List users with access to a namespace
+    // Get users with access to a namespace
     rpc GetUserNamespaceAssignments(GetUserNamespaceAssignmentsRequest) returns (GetUserNamespaceAssignmentsResponse) {
         option (google.api.http) = {
             get: "/cloud/namespaces/{namespace}/user-assignments",
@@ -1257,7 +1257,7 @@ service CloudService {
         };
     }
 
-    // List service accounts with access to a namespace
+    // Get service accounts with access to a namespace
     rpc GetServiceAccountNamespaceAssignments(GetServiceAccountNamespaceAssignmentsRequest) returns (GetServiceAccountNamespaceAssignmentsResponse) {
         option (google.api.http) = {
             get: "/cloud/namespaces/{namespace}/service-account-assignments",
@@ -1273,7 +1273,7 @@ service CloudService {
         };
     }
 
-    // List user groups with access to a namespace
+    // Get user groups with access to a namespace
     rpc GetUserGroupNamespaceAssignments(GetUserGroupNamespaceAssignmentsRequest) returns (GetUserGroupNamespaceAssignmentsResponse) {
         option (google.api.http) = {
             get: "/cloud/namespaces/{namespace}/user-group-assignments",

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -1240,4 +1240,52 @@ service CloudService {
             };
         };
     }
+
+    // List users with access to a namespace
+    rpc GetUserNamespaceAssignments(GetUserNamespaceAssignmentsRequest) returns (GetUserNamespaceAssignmentsResponse) {
+        option (google.api.http) = {
+            get: "/cloud/namespaces/{namespace}/user-assignments",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Users"];
+            summary: "List users with access to a namespace";
+            description: "Returns the users that have access to the namespace, including each user's namespace-level access and whether that access is inherited from an account or project role.";
+            external_docs: {
+                url: "https://docs.temporal.io/cloud/users";
+                description: "Users documentation";
+            };
+        };
+    }
+
+    // List service accounts with access to a namespace
+    rpc GetServiceAccountNamespaceAssignments(GetServiceAccountNamespaceAssignmentsRequest) returns (GetServiceAccountNamespaceAssignmentsResponse) {
+        option (google.api.http) = {
+            get: "/cloud/namespaces/{namespace}/service-account-assignments",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Service Accounts"];
+            summary: "List service accounts with access to a namespace";
+            description: "Returns the service accounts that have access to the namespace, including each service account's namespace-level access and whether that access is inherited from an account or project role.";
+            external_docs: {
+                url: "https://docs.temporal.io/cloud/service-accounts";
+                description: "Service Accounts documentation";
+            };
+        };
+    }
+
+    // List user groups with access to a namespace
+    rpc GetUserGroupNamespaceAssignments(GetUserGroupNamespaceAssignmentsRequest) returns (GetUserGroupNamespaceAssignmentsResponse) {
+        option (google.api.http) = {
+            get: "/cloud/namespaces/{namespace}/user-group-assignments",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Groups"];
+            summary: "List user groups with access to a namespace";
+            description: "Returns the user groups that have access to the namespace, including each group's namespace-level access and whether that access is inherited from an account or project role.";
+            external_docs: {
+                url: "https://docs.temporal.io/cloud/user-groups";
+                description: "User groups documentation";
+            };
+        };
+    }
 }

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -1248,8 +1248,8 @@ service CloudService {
         };
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: ["Users"];
-            summary: "List users with access to a namespace";
-            description: "Returns the users that have access to the namespace, including each user's namespace permission.";
+            summary: "Get users with access to a namespace";
+            description: "Returns the users that have access to the namespace, including each user's namespace-level access.";
             external_docs: {
                 url: "https://docs.temporal.io/cloud/users";
                 description: "Users documentation";
@@ -1265,7 +1265,7 @@ service CloudService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: ["Service Accounts"];
             summary: "List service accounts with access to a namespace";
-            description: "Returns the service accounts that have access to the namespace, including each service account's namespace permission.";
+            description: "Returns the service accounts that have access to the namespace, including each service account's namespace-level access.";
             external_docs: {
                 url: "https://docs.temporal.io/cloud/service-accounts";
                 description: "Service Accounts documentation";
@@ -1281,7 +1281,7 @@ service CloudService {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             tags: ["Groups"];
             summary: "List user groups with access to a namespace";
-            description: "Returns the user groups that have access to the namespace, including each group's namespace permission.";
+            description: "Returns the user groups that have access to the namespace, including each group's namespace-level access.";
             external_docs: {
                 url: "https://docs.temporal.io/cloud/user-groups";
                 description: "User groups documentation";

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -347,3 +347,42 @@ message CustomRole {
     // Will not be set if the custom role has never been modified.
     google.protobuf.Timestamp last_modified_time = 7;
 }
+
+message UserNamespaceAssignment {
+    // The ID of the user.
+    string id = 1;
+    // The email of the user.
+    string email = 2;
+    // The access assigned to the user at the namespace level.
+    NamespaceAccess namespace_access = 3;
+    // True if the user has inherited access to the namespace through an account or project role.
+    bool inherited_access = 4;
+    // The current resource version of the user.
+    string resource_version = 5;
+}
+
+message ServiceAccountNamespaceAssignment {
+    // The ID of the service account.
+    string id = 1;
+    // The name of the service account.
+    string name = 2;
+    // The access assigned to the service account at the namespace level.
+    NamespaceAccess namespace_access = 3;
+    // True if the service account has inherited access to the namespace through an account or project role.
+    bool inherited_access = 4;
+    // The current resource version of the service account.
+    string resource_version = 5;
+}
+
+message UserGroupNamespaceAssignment {
+    // The ID of the group.
+    string id = 1;
+    // The display name of the group.
+    string display_name = 2;
+    // The access assigned to the group at the namespace level.
+    NamespaceAccess namespace_access = 3;
+    // True if the group has inherited access to the namespace through an account or project role.
+    bool inherited_access = 4;
+    // The current resource version of the group.
+    string resource_version = 5;
+}


### PR DESCRIPTION
Publish `Get<>NamespaceAssignments` APIs.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proto-only, additive read APIs; no auth or mutation logic in this diff, though responses expose namespace access metadata.
> 
> **Overview**
> Adds **namespace-centric read APIs** to Temporal Cloud Ops: list **users**, **service accounts**, and **user groups** that can access a given namespace, with pagination (`page_size` / `page_token`, default 100, max 1000).
> 
> Each endpoint is exposed on `CloudService` as a **GET** under `/cloud/namespaces/{namespace}/…` (`user-assignments`, `service-account-assignments`, `user-group-assignments`), with OpenAPI metadata aligned to existing Users / Service Accounts / Groups docs.
> 
> New identity types **`UserNamespaceAssignment`**, **`ServiceAccountNamespaceAssignment`**, and **`UserGroupNamespaceAssignment`** return principal id, display identifier (email / name / display name), **`NamespaceAccess`**, an **`inherited_access`** flag for account/project-derived access, and **`resource_version`** for optimistic updates elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb6b7222c448fc092affcbeb32b23175a74f74c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->