### PR TITLE
Add azure_pe_resource_id field to PrivateConnectivityRule

### DIFF
--- a/temporal/api/cloud/connectivityrule/v1/message.proto
+++ b/temporal/api/cloud/connectivityrule/v1/message.proto
@@ -53,7 +53,11 @@ message PublicConnectivityRule {
 
 // A private connectivity rule allows connections from a specific private vpc only.
 message PrivateConnectivityRule {
-  // Connection id provided to enforce the private connectivity. This is required both by AWS and GCP.
+  // Connection id provided to enforce the private connectivity.
+  // For AWS: VPC endpoint ID (e.g. "vpce-0123456789abcdef0").
+  // For GCP: PSC connection ID (numeric string).
+  // For Azure: not set by the customer; populated internally with the PPv2 LinkID
+  // returned by the infra plane during Private Endpoint connection approval.
   string connection_id = 1;
 
   // For GCP private connectivity service, GCP needs both GCP project id and the Private Service Connect Connection IDs
@@ -61,8 +65,13 @@ message PrivateConnectivityRule {
   string gcp_project_id = 2;
 
   // The region of the connectivity rule. This should align with the namespace.
-  // Example: "aws-us-west-2"
+  // Example: "aws-us-west-2", "gcp-us-central1", "azure-eastus"
   string region = 3;
 
   reserved 4;
+
+  // The ARM resource ID of the customer's Azure Private Endpoint.
+  // Required for Azure private connectivity rules.
+  // Example: "/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}"
+  string azure_pe_resource_id = 5;
 }


### PR DESCRIPTION
## Summary

- Adds `azure_pe_resource_id` field (field 5) to `PrivateConnectivityRule` for Azure Private Link connectivity rules


Pairs with saas-proto PR: https://github.com/temporalio/saas-proto/pull/1189