### PR TITLE
feat: projects CLDIAM-931

### DIFF
--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -19,6 +19,7 @@ import "temporal/api/cloud/region/v1/message.proto";
 import "temporal/api/cloud/account/v1/message.proto";
 import "temporal/api/cloud/usage/v1/message.proto";
 import "temporal/api/cloud/connectivityrule/v1/message.proto";
+import "temporal/api/cloud/project/v1/message.proto";
 import "temporal/api/cloud/auditlog/v1/message.proto";
 import "temporal/api/cloud/billing/v1/message.proto";
 
@@ -150,6 +151,8 @@ message CreateNamespaceRequest {
     // The tags to add to the namespace.
     // Note: This field can be set by global admins or account owners only.
     map<string, string> tags = 4;
+    // The id of the project to create the namespace in - optional.
+    string project_id = 5;
 }
 
 message CreateNamespaceResponse {
@@ -170,6 +173,8 @@ message GetNamespacesRequest {
     // Filter namespaces by their name.
     // Optional, defaults to empty.
     string name = 3;
+    // Filter namespaces by project id - optional.
+    string project_id = 4;
 }
 
 message GetNamespacesResponse {
@@ -419,6 +424,8 @@ message GetNexusEndpointsRequest {
 
     // Filter endpoints by their name - optional, treated as an AND if specified. Specifying this will result in zero or one results.
     string name = 5;
+    // Filter endpoints by their project id - optional.
+    string project_id = 6;
 }
 
 message GetNexusEndpointsResponse {
@@ -445,6 +452,8 @@ message CreateNexusEndpointRequest {
 
     // The id to use for this async operation - optional.
     string async_operation_id = 2;
+    // The id of the project to associate this endpoint with - optional.
+    string project_id = 3;
 }
 
 message CreateNexusEndpointResponse {
@@ -695,6 +704,23 @@ message GetServiceAccountsResponse {
     string next_page_token = 2;
 }
 
+message GetProjectScopedServiceAccountsRequest {
+    // The project to list project scoped service accounts for.
+    string project_id = 1;
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 2;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 3;
+}
+
+message GetProjectScopedServiceAccountsResponse {
+    // The list of project scoped service accounts in ascending ID order.
+    repeated temporal.api.cloud.identity.v1.ServiceAccount service_accounts = 1;
+    // The next page token, set if there is another page.
+    string next_page_token = 2;
+}
+
 message UpdateServiceAccountRequest {
     // The ID of the service account to update.
     string service_account_id = 1;
@@ -913,6 +939,8 @@ message CreateConnectivityRuleRequest {
     // The id to use for this async operation.
     // Optional, if not provided a random id will be generated.
     string async_operation_id = 2;
+    // The ID of the project this connectivity rule belongs to - optional.
+    string project_id = 3;
 }
 
 message CreateConnectivityRuleResponse {
@@ -940,6 +968,8 @@ message GetConnectivityRulesRequest {
     string page_token = 2;
     // Filter connectivity rule by the namespace id.
     string namespace = 3;
+    // Filter connectivity rules by project id - optional.
+    string project_id = 4;
 }
 
 message GetConnectivityRulesResponse {
@@ -1169,6 +1199,57 @@ message DeleteCustomRoleResponse {
     temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
 }
 
+message GetUserProjectAssignmentsRequest {
+    // The id of the project to get users for.
+    string project_id = 1;
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 2;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 3;
+}
+
+message GetUserProjectAssignmentsResponse {
+    // The list of users with access to the project.
+    repeated temporal.api.cloud.identity.v1.UserProjectAssignment users = 1;
+    // The next page's token.
+    string next_page_token = 2;
+}
+
+message GetServiceAccountProjectAssignmentsRequest {
+    // The id of the project to get service accounts for.
+    string project_id = 1;
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 2;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 3;
+}
+
+message GetServiceAccountProjectAssignmentsResponse {
+    // The list of service accounts with access to the project.
+    repeated temporal.api.cloud.identity.v1.ServiceAccountProjectAssignment service_accounts = 1;
+    // The next page's token.
+    string next_page_token = 2;
+}
+
+message GetUserGroupProjectAssignmentsRequest {
+    // The id of the project to get user groups for.
+    string project_id = 1;
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 2;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 3;
+}
+
+message GetUserGroupProjectAssignmentsResponse {
+    // The list of user groups with access to the project.
+    repeated temporal.api.cloud.identity.v1.UserGroupProjectAssignment groups = 1;
+    // The next page's token.
+    string next_page_token = 2;
+}
+
 message GetUserNamespaceAssignmentsRequest {
     // The namespace to get users for.
     string namespace = 1;
@@ -1218,4 +1299,137 @@ message GetUserGroupNamespaceAssignmentsResponse {
     repeated temporal.api.cloud.identity.v1.UserGroupNamespaceAssignment groups = 1;
     // The next page's token.
     string next_page_token = 2;
+}
+
+message GetProjectsRequest {
+    // The requested size of the page to retrieve - optional.
+    // Cannot exceed 1000. Defaults to 100.
+    int32 page_size = 1;
+    // The page token if this is continuing from another response - optional.
+    string page_token = 2;
+    // Filter by project IDs - optional.
+    repeated string project_ids = 3;
+}
+
+message GetProjectsResponse {
+    // The list of projects in ascending ids order
+    repeated temporal.api.cloud.project.v1.Project projects = 1;
+    // The next page's token
+    string next_page_token = 2;
+}
+
+message GetProjectRequest {
+    // The id of the project to get
+    string project_id = 1;
+}
+
+message GetProjectResponse {
+    // The project
+    temporal.api.cloud.project.v1.Project project = 1;
+}
+
+message CreateProjectRequest {
+    // The spec for the project to create.
+    temporal.api.cloud.project.v1.ProjectSpec spec = 1;
+    // The id to use for this async operation.
+    // Optional, if not provided a random id will be generated.
+    string async_operation_id = 2;
+}
+
+message CreateProjectResponse {
+    // The id of the project that was created.
+    string project_id = 1;
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 2;
+}
+
+message UpdateProjectRequest {
+    // The id of the project to update.
+    string project_id = 1;
+    // The new project specification.
+    temporal.api.cloud.project.v1.ProjectSpec spec = 2;
+    // The version of the project for which this update is intended for.
+    // The latest version can be found in the GetProject operation response.
+    string resource_version = 3;
+    // The id to use for this async operation.
+    // Optional, if not provided a random id will be generated.
+    string async_operation_id = 4;
+}
+
+message UpdateProjectResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message DeleteProjectRequest {
+    // The id of the project to delete.
+    string project_id = 1;
+    // The version of the project for which this delete is intended for.
+    // The latest version can be found in the GetProject operation response.
+    string resource_version = 2;
+    // The id to use for this async operation.
+    // Optional, if not provided a random id will be generated.
+    string async_operation_id = 3;
+}
+
+message DeleteProjectResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message SetUserProjectAccessRequest {
+    // The project to set permissions for.
+    string project_id = 1;
+    // The id of the user to set permissions for.
+    string user_id = 2;
+    // The project access to assign the user. If left empty, the user will be removed from the project access.
+    temporal.api.cloud.identity.v1.ProjectAccess access = 3;
+    // The version of the user for which this update is intended for.
+    // The latest version can be found in the GetUser operation response.
+    string resource_version = 4;
+    // The id to use for this async operation - optional.
+    string async_operation_id = 5;
+}
+
+message SetUserProjectAccessResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message SetUserGroupProjectAccessRequest {
+    // The project to set permissions for.
+    string project_id = 1;
+    // The id of the group to set permissions for.
+    string group_id = 2;
+    // The project access to assign the group. If left empty, the group will be removed from the project access.
+    temporal.api.cloud.identity.v1.ProjectAccess access = 3;
+    // The version of the group for which this update is intended for.
+    // The latest version can be found in the GetGroup operation response.
+    string resource_version = 4;
+    // The id to use for this async operation - optional.
+    string async_operation_id = 5;
+}
+
+message SetUserGroupProjectAccessResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
+}
+
+message SetServiceAccountProjectAccessRequest {
+    // The project to set permissions for.
+    string project_id = 1;
+    // The id of the service account to set permissions for.
+    string service_account_id = 2;
+    // The project access to assign the service account. If left empty, the service account will be removed from the project access.
+    temporal.api.cloud.identity.v1.ProjectAccess access = 3;
+    // The version of the service account for which this update is intended for.
+    // The latest version can be found in the GetServiceAccount operation response.
+    string resource_version = 4;
+    // The id to use for this async operation - optional.
+    string async_operation_id = 5;
+}
+
+message SetServiceAccountProjectAccessResponse {
+    // The async operation.
+    temporal.api.cloud.operation.v1.AsyncOperation async_operation = 1;
 }

--- a/temporal/api/cloud/cloudservice/v1/request_response.proto
+++ b/temporal/api/cloud/cloudservice/v1/request_response.proto
@@ -152,6 +152,7 @@ message CreateNamespaceRequest {
     // Note: This field can be set by global admins or account owners only.
     map<string, string> tags = 4;
     // The id of the project to create the namespace in - optional.
+    // If not set, the namespace will be created in the account's default project.
     string project_id = 5;
 }
 
@@ -453,6 +454,7 @@ message CreateNexusEndpointRequest {
     // The id to use for this async operation - optional.
     string async_operation_id = 2;
     // The id of the project to associate this endpoint with - optional.
+    // If not set, the endpoint will be created in the account's default project.
     string project_id = 3;
 }
 
@@ -940,6 +942,7 @@ message CreateConnectivityRuleRequest {
     // Optional, if not provided a random id will be generated.
     string async_operation_id = 2;
     // The ID of the project this connectivity rule belongs to - optional.
+    // If not set, the connectivity rule will be created in the account's default project.
     string project_id = 3;
 }
 

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -49,6 +49,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
         {name: "Regions"; description: "Query available regions"},
         {name: "Account"; description: "Manage account settings and usage"},
         {name: "Custom Roles"; description: "Manage custom roles and their permissions"},
+        {name: "Projects"; description: "Manage projects and project-level access control"},
         {name: "Operations"; description: "Query async operation status"}
     ];
 };
@@ -1286,6 +1287,155 @@ service CloudService {
                 url: "https://docs.temporal.io/cloud/user-groups";
                 description: "User groups documentation";
             };
+        };
+    }
+
+    // Get all projects
+    rpc GetProjects(GetProjectsRequest) returns (GetProjectsResponse) {
+        option (google.api.http) = {
+            get: "/cloud/projects",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "List all projects";
+            description: "Returns a list of all projects in the account.";
+        };
+    }
+
+    // Get a project
+    rpc GetProject(GetProjectRequest) returns (GetProjectResponse) {
+        option (google.api.http) = {
+            get: "/cloud/projects/{project_id}",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "Get a project";
+            description: "Returns the project with the given id.";
+        };
+    }
+
+    // Create a new project
+    rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse) {
+        option (google.api.http) = {
+            post: "/cloud/projects",
+            body: "*"
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "Create a project";
+            description: "Creates a new project.";
+        };
+    }
+
+    // Update a project
+    rpc UpdateProject(UpdateProjectRequest) returns (UpdateProjectResponse) {
+        option (google.api.http) = {
+            post: "/cloud/projects/{project_id}",
+            body: "*"
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "Update a project";
+            description: "Updates the configuration of an existing project.";
+        };
+    }
+
+    // Delete a project
+    rpc DeleteProject(DeleteProjectRequest) returns (DeleteProjectResponse) {
+        option (google.api.http) = {
+            delete: "/cloud/projects/{project_id}",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "Delete a project";
+            description: "Deletes an existing project.";
+        };
+    }
+
+    // Set a user's access to a project
+    rpc SetUserProjectAccess(SetUserProjectAccessRequest) returns (SetUserProjectAccessResponse) {
+        option (google.api.http) = {
+            post: "/cloud/projects/{project_id}/users/{user_id}/access",
+            body: "*"
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "Set user project access";
+            description: "Sets or removes a user's access to a project.";
+        };
+    }
+
+    // Set a user group's access to a project
+    rpc SetUserGroupProjectAccess(SetUserGroupProjectAccessRequest) returns (SetUserGroupProjectAccessResponse) {
+        option (google.api.http) = {
+            post: "/cloud/projects/{project_id}/user-groups/{group_id}/access",
+            body: "*"
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "Set user group project access";
+            description: "Sets or removes a user group's access to a project.";
+        };
+    }
+
+    // Set a service account's access to a project
+    rpc SetServiceAccountProjectAccess(SetServiceAccountProjectAccessRequest) returns (SetServiceAccountProjectAccessResponse) {
+        option (google.api.http) = {
+            post: "/cloud/projects/{project_id}/service-accounts/{service_account_id}/access",
+            body: "*"
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "Set service account project access";
+            description: "Sets or removes a service account's access to a project.";
+        };
+    }
+
+    // Get users with access to a project
+    rpc GetUserProjectAssignments(GetUserProjectAssignmentsRequest) returns (GetUserProjectAssignmentsResponse) {
+        option (google.api.http) = {
+            get: "/cloud/projects/{project_id}/user-assignments",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "List users with access to a project";
+            description: "Returns the users that have access to the project, including each user's project-level access.";
+        };
+    }
+
+    // Get service accounts with access to a project
+    rpc GetServiceAccountProjectAssignments(GetServiceAccountProjectAssignmentsRequest) returns (GetServiceAccountProjectAssignmentsResponse) {
+        option (google.api.http) = {
+            get: "/cloud/projects/{project_id}/service-account-assignments",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "List service accounts with access to a project";
+            description: "Returns the service accounts that have access to the project, including each service account's project-level access.";
+        };
+    }
+
+    // Get user groups with access to a project
+    rpc GetUserGroupProjectAssignments(GetUserGroupProjectAssignmentsRequest) returns (GetUserGroupProjectAssignmentsResponse) {
+        option (google.api.http) = {
+            get: "/cloud/projects/{project_id}/user-group-assignments",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "List user groups with access to a project";
+            description: "Returns the user groups that have access to the project, including each group's project-level access.";
+        };
+    }
+
+    // Get service accounts scoped to a project
+    rpc GetProjectScopedServiceAccounts(GetProjectScopedServiceAccountsRequest) returns (GetProjectScopedServiceAccountsResponse) {
+        option (google.api.http) = {
+            get: "/cloud/projects/{project_id}/service-accounts",
+        };
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            tags: ["Projects"];
+            summary: "List project-scoped service accounts";
+            description: "Returns the service accounts that are scoped to the project.";
         };
     }
 }

--- a/temporal/api/cloud/cloudservice/v1/service.proto
+++ b/temporal/api/cloud/cloudservice/v1/service.proto
@@ -49,7 +49,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
         {name: "Regions"; description: "Query available regions"},
         {name: "Account"; description: "Manage account settings and usage"},
         {name: "Custom Roles"; description: "Manage custom roles and their permissions"},
-        {name: "Projects"; description: "Manage projects and project-level access control"},
+        {name: "Projects"; description: "Manage projects and project-level access control. Projects are an upcoming feature and may not be enabled for your account. Contact Temporal support to request access."},
         {name: "Operations"; description: "Query async operation status"}
     ];
 };

--- a/temporal/api/cloud/connectivityrule/v1/message.proto
+++ b/temporal/api/cloud/connectivityrule/v1/message.proto
@@ -32,6 +32,9 @@ message ConnectivityRule {
 
   // The date and time when the connectivity rule was created.
   google.protobuf.Timestamp created_time = 7;
+
+  // The ID of the project this connectivity rule belongs to.
+  string project_id = 8;
 }
 
 // The connectivity rule specification passed in on create/update operations.

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -71,12 +71,31 @@ enum OwnerType {
     OWNER_TYPE_SERVICE_ACCOUNT = 2; // The owner is a service account.
 }
 
+message ProjectAccess {
+    ProjectRole role = 1;
+
+    enum ProjectRole {
+        PROJECT_ROLE_UNSPECIFIED = 0;
+        PROJECT_ROLE_ADMIN = 1;
+        PROJECT_ROLE_WRITE = 2;
+        PROJECT_ROLE_READ = 3;
+        PROJECT_ROLE_LIST = 4;
+        PROJECT_ROLE_CONTRIBUTE = 5;
+        PROJECT_ROLE_MEMBER = 6;
+        PROJECT_ROLE_DEVELOPER = 7;
+    }
+}
+
 message Access {
     // The account access
     AccountAccess account_access = 1;
     // The map of namespace accesses
     // The key is the namespace name and the value is the access to the namespace
     map<string, NamespaceAccess> namespace_accesses = 2;
+    // The map of project accesses
+    // The key is the project ID and the value is the access to the project
+    // temporal:versioning:min_version=v0.18.0
+    map<string, ProjectAccess> project_accesses = 3;
     // List of custom role IDs assigned to the user or service account.
     // Deprecated: Not supported after v0.12.0 api version. Use account_access.custom_roles instead.
     // temporal:versioning:max_version=v0.12.0
@@ -88,6 +107,16 @@ message NamespaceScopedAccess {
     string namespace = 1;
     // The namespace access assigned to the service account - mutable.
     NamespaceAccess access = 2;
+}
+
+message ProjectScopedAccess {
+    // The ID of the project the service account is assigned to - immutable.
+    string project_id = 1;
+    // The project access assigned to the service account - mutable.
+    ProjectAccess access = 2;
+    // The map of namespace accesses - mutable.
+    // The key is the namespace name and the value is the access to the namespace.
+    map<string, NamespaceAccess> namespace_accesses = 3;
 }
 
 message UserSpec {
@@ -244,6 +273,10 @@ message ServiceAccountSpec {
     // Refer to `NamespaceScopedAccess` for details.
     NamespaceScopedAccess namespace_scoped_access = 4;
 
+    // The project scoped access assigned to the service account.
+    // If set, creates a project scoped service account (limited to a single project).
+    ProjectScopedAccess project_scoped_access = 5;
+
     // The description associated with the service account - optional.
     // The description is mutable.
     string description = 3;
@@ -348,6 +381,18 @@ message CustomRole {
     google.protobuf.Timestamp last_modified_time = 7;
 }
 
+message UserProjectAssignment {
+    // The id of the user
+    string id = 1;
+    // The email of the user
+    string email = 2;
+    // The access assigned to the user at the project level.
+    ProjectAccess project_access = 3;
+    // True if the user has inherited access to the project through an account role
+    bool inherited_access = 4;
+    string resource_version = 5;
+}
+
 message UserNamespaceAssignment {
     // The ID of the user.
     string id = 1;
@@ -361,6 +406,18 @@ message UserNamespaceAssignment {
     string resource_version = 5;
 }
 
+message ServiceAccountProjectAssignment {
+    // The id of the service account.
+    string id = 1;
+    // The name of the service account.
+    string name = 2;
+    // The access assigned to the service account at the project level.
+    ProjectAccess project_access = 3;
+    // True if the user has inherited access to the project through an account role
+    bool inherited_access = 4;
+    string resource_version = 5;
+}
+
 message ServiceAccountNamespaceAssignment {
     // The ID of the service account.
     string id = 1;
@@ -371,6 +428,18 @@ message ServiceAccountNamespaceAssignment {
     // True if the service account has inherited access to the namespace through an account or project role.
     bool inherited_access = 4;
     // The current resource version of the service account.
+    string resource_version = 5;
+}
+
+message UserGroupProjectAssignment {
+    // The id of the group
+    string id = 1;
+    // The display name of the group
+    string display_name = 2;
+    // The access assigned to the group at the project level.
+    ProjectAccess project_access = 3;
+    // True if the group has inherited access to the project through an account role
+    bool inherited_access = 4;
     string resource_version = 5;
 }
 

--- a/temporal/api/cloud/identity/v1/message.proto
+++ b/temporal/api/cloud/identity/v1/message.proto
@@ -76,13 +76,13 @@ message ProjectAccess {
 
     enum ProjectRole {
         PROJECT_ROLE_UNSPECIFIED = 0;
-        PROJECT_ROLE_ADMIN = 1;
-        PROJECT_ROLE_WRITE = 2;
-        PROJECT_ROLE_READ = 3;
-        PROJECT_ROLE_LIST = 4;
-        PROJECT_ROLE_CONTRIBUTE = 5;
-        PROJECT_ROLE_MEMBER = 6;
-        PROJECT_ROLE_DEVELOPER = 7;
+        PROJECT_ROLE_ADMIN = 1;       // Full access to the project, including managing project membership.
+        PROJECT_ROLE_WRITE = 2;       // Write access to project resources.
+        PROJECT_ROLE_READ = 3;        // Read-only access to project resources.
+        PROJECT_ROLE_LIST = 4;        // Access to list resources within the project.
+        PROJECT_ROLE_CONTRIBUTE = 5;  // Access to contribute to workflows within the project.
+        PROJECT_ROLE_MEMBER = 6;      // Basic membership; grants read-only access to the project.
+        PROJECT_ROLE_DEVELOPER = 7;   // Inherited from the account developer role; cannot be assigned directly.
     }
 }
 
@@ -262,7 +262,7 @@ message ServiceAccountSpec {
     // The name is mutable, but must be unique across all your active service accounts.
     string name = 1;
 
-    // Note: one of `Access` or `NamespaceScopedAccess` must be provided, but not both.
+    // Note: one of `Access`, `ProjectScopedAccess`, or `NamespaceScopedAccess` must be provided.
     // The access assigned to the service account.
     // If set, creates an account scoped service account.
     // The access is mutable.
@@ -390,6 +390,7 @@ message UserProjectAssignment {
     ProjectAccess project_access = 3;
     // True if the user has inherited access to the project through an account role
     bool inherited_access = 4;
+    // The current resource version of the user.
     string resource_version = 5;
 }
 

--- a/temporal/api/cloud/namespace/v1/message.proto
+++ b/temporal/api/cloud/namespace/v1/message.proto
@@ -361,6 +361,8 @@ message Namespace {
     // The status of each replica where the namespace is available.
     // temporal:versioning:min_version=v0.13.0
     repeated Replica replicas = 18;
+    // The id of the project this namespace belongs to.
+    string project_id = 17;
 }
 
 message NamespaceRegionStatus {

--- a/temporal/api/cloud/nexus/v1/message.proto
+++ b/temporal/api/cloud/nexus/v1/message.proto
@@ -87,4 +87,7 @@ message Endpoint {
 
     // The date and time when the endpoint was last modified.
     google.protobuf.Timestamp last_modified_time = 7;
+
+    // The id of the project this endpoint belongs to.
+    string project_id = 8;
 }

--- a/temporal/api/cloud/project/v1/message.proto
+++ b/temporal/api/cloud/project/v1/message.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package temporal.api.cloud.project.v1;
+
+option go_package = "go.temporal.io/api/cloud/project/v1;project";
+option java_package = "io.temporal.api.cloud.project.v1";
+option java_multiple_files = true;
+option java_outer_classname = "MessageProto";
+option ruby_package = "Temporalio::Api::Cloud::Project::V1";
+option csharp_namespace = "Temporalio.Api.Cloud.Project.V1";
+
+import "temporal/api/cloud/resource/v1/message.proto";
+import "google/protobuf/timestamp.proto";
+
+message ProjectSpec {
+  // The display name of the project.
+  string display_name = 1;
+  // A description of the project.
+  string description = 2;
+  // The lifecycle configuration for the project.
+  LifecycleSpec lifecycle = 3;
+}
+
+message LifecycleSpec {
+  // If true, the project cannot be deleted.
+  bool enable_delete_protection = 1;
+}
+
+message Project {
+  // The id of the user
+  string id = 1;
+  // The project specification
+  ProjectSpec spec = 2;
+  // The current version of the project specification
+  // The next update operation will have to include this version
+  string resource_version = 3;
+  // The current state of the project.
+  // For any failed state, reach out to Temporal Cloud support for remediation.
+  temporal.api.cloud.resource.v1.ResourceState state = 4;
+  // The id of the async operation that is creating/updating/deleting the project, if any
+  string async_operation_id = 5;
+  // The date and time when the project was created
+  google.protobuf.Timestamp created_time = 6;
+  // The date and time when the project was last modified
+  // Will not be set if the project has never been modified
+  google.protobuf.Timestamp last_modified_time = 7;
+}

--- a/temporal/api/cloud/project/v1/message.proto
+++ b/temporal/api/cloud/project/v1/message.proto
@@ -1,3 +1,6 @@
+// Projects are an upcoming feature and may not be enabled for your account.
+// Contact Temporal support to request access.
+
 syntax = "proto3";
 
 package temporal.api.cloud.project.v1;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add project APIs and fields. 
<!-- Describe what has changed in this PR -->

## Why?
Pre-release of projects
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large IAM and authorization surface area (new project roles, assignment APIs, and a third service-account scope) that will govern access to core resources; proto-only here but downstream enforcement must stay consistent with existing namespace/account rules.
> 
> **Overview**
> Introduces **Projects** as a new organizational layer in Temporal Cloud Ops API (pre-release; feature-gated per OpenAPI docs).
> 
> **Project lifecycle:** New `project/v1` messages and `CloudService` RPCs for list/get/create/update/delete under `/cloud/projects`, with optional delete protection on `ProjectSpec`.
> 
> **Project-level access control:** Adds `ProjectAccess` roles, `project_accesses` on user/group `Access` (from API v0.18.0), and parallel APIs to namespace IAM: set access for users, groups, and service accounts; list assignments per project; list **project-scoped** service accounts (new `ProjectScopedAccess` on `ServiceAccountSpec`, including per-namespace overrides within a project).
> 
> **Resource scoping:** Optional `project_id` on create/list for namespaces, Nexus endpoints, and connectivity rules (default account project when omitted). Read models expose `project_id` on `Namespace`, `Endpoint`, and `ConnectivityRule`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032f3d40fbdaed709cd045eed63c49dacef7415a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->